### PR TITLE
Clean up flake8 warnings

### DIFF
--- a/swagger_client/__init__.py
+++ b/swagger_client/__init__.py
@@ -5,7 +5,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/api/connection_api.py
+++ b/swagger_client/api/connection_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org
@@ -94,8 +96,9 @@ class ConnectionApi(object):
         # verify the required parameter 'connection_id' is set
         if "connection_id" not in params or params["connection_id"] is None:
             raise ValueError(
-                "Missing the required parameter `connection_id` when calling `delete_connection`"
-            )  # noqa: E501
+                "Missing the required parameter `connection_id` "
+                "when calling `delete_connection`"
+            )
 
         collection_formats = {}
 
@@ -194,8 +197,9 @@ class ConnectionApi(object):
         # verify the required parameter 'connection_id' is set
         if "connection_id" not in params or params["connection_id"] is None:
             raise ValueError(
-                "Missing the required parameter `connection_id` when calling `getconnection_by_id`"
-            )  # noqa: E501
+                "Missing the required parameter `connection_id` "
+                "when calling `getconnection_by_id`"
+            )
 
         collection_formats = {}
 
@@ -295,8 +299,9 @@ class ConnectionApi(object):
         # verify the required parameter 'body' is set
         if "body" not in params or params["body"] is None:
             raise ValueError(
-                "Missing the required parameter `body` when calling `place_connection`"
-            )  # noqa: E501
+                "Missing the required parameter `body` when "
+                "calling `place_connection`"
+            )
 
         collection_formats = {}
 

--- a/swagger_client/api/link_api.py
+++ b/swagger_client/api/link_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/api/node_api.py
+++ b/swagger_client/api/node_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/api/topology_api.py
+++ b/swagger_client/api/topology_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org
@@ -188,13 +190,15 @@ class TopologyApi(object):
         # verify the required parameter 'topology_id' is set
         if "topology_id" not in params or params["topology_id"] is None:
             raise ValueError(
-                "Missing the required parameter `topology_id` when calling `get_topologyby_version`"
-            )  # noqa: E501
+                "Missing the required parameter `topology_id` "
+                "when calling `get_topologyby_version`"
+            )
         # verify the required parameter 'version' is set
         if "version" not in params or params["version"] is None:
             raise ValueError(
-                "Missing the required parameter `version` when calling `get_topologyby_version`"
-            )  # noqa: E501
+                "Missing the required parameter `version` "
+                "when calling `get_topologyby_version`"
+            )
 
         collection_formats = {}
 
@@ -302,8 +306,9 @@ class TopologyApi(object):
         # verify the required parameter 'topology_id' is set
         if "topology_id" not in params or params["topology_id"] is None:
             raise ValueError(
-                "Missing the required parameter `topology_id` when calling `topology_version`"
-            )  # noqa: E501
+                "Missing the required parameter `topology_id` "
+                "when calling `topology_version`"
+            )
 
         collection_formats = {}
 

--- a/swagger_client/api/user_api.py
+++ b/swagger_client/api/user_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org
@@ -92,8 +94,9 @@ class UserApi(object):
         # verify the required parameter 'body' is set
         if "body" not in params or params["body"] is None:
             raise ValueError(
-                "Missing the required parameter `body` when calling `create_user`"
-            )  # noqa: E501
+                "Missing the required parameter `body` "
+                "when calling `create_user`"
+            )
 
         collection_formats = {}
 
@@ -197,7 +200,8 @@ class UserApi(object):
         # verify the required parameter 'body' is set
         if "body" not in params or params["body"] is None:
             raise ValueError(
-                "Missing the required parameter `body` when calling `create_users_with_array_input`"
+                "Missing the required parameter `body` "
+                "when calling `create_users_with_array_input`"
             )  # noqa: E501
 
         collection_formats = {}
@@ -302,8 +306,9 @@ class UserApi(object):
         # verify the required parameter 'body' is set
         if "body" not in params or params["body"] is None:
             raise ValueError(
-                "Missing the required parameter `body` when calling `create_users_with_list_input`"
-            )  # noqa: E501
+                "Missing the required parameter `body` "
+                "when calling `create_users_with_list_input`"
+            )
 
         collection_formats = {}
 
@@ -407,8 +412,9 @@ class UserApi(object):
         # verify the required parameter 'username' is set
         if "username" not in params or params["username"] is None:
             raise ValueError(
-                "Missing the required parameter `username` when calling `delete_user`"
-            )  # noqa: E501
+                "Missing the required parameter `username` "
+                "when calling `delete_user`"
+            )
 
         collection_formats = {}
 
@@ -505,8 +511,9 @@ class UserApi(object):
         # verify the required parameter 'username' is set
         if "username" not in params or params["username"] is None:
             raise ValueError(
-                "Missing the required parameter `username` when calling `get_user_by_name`"
-            )  # noqa: E501
+                "Missing the required parameter `username` "
+                "when calling `get_user_by_name`"
+            )
 
         collection_formats = {}
 
@@ -610,13 +617,15 @@ class UserApi(object):
         # verify the required parameter 'username' is set
         if "username" not in params or params["username"] is None:
             raise ValueError(
-                "Missing the required parameter `username` when calling `login_user`"
-            )  # noqa: E501
+                "Missing the required parameter `username` "
+                "when calling `login_user`"
+            )
         # verify the required parameter 'password' is set
         if "password" not in params or params["password"] is None:
             raise ValueError(
-                "Missing the required parameter `password` when calling `login_user`"
-            )  # noqa: E501
+                "Missing the required parameter `password` "
+                "when calling `login_user`"
+            )
 
         collection_formats = {}
 
@@ -807,13 +816,15 @@ class UserApi(object):
         # verify the required parameter 'body' is set
         if "body" not in params or params["body"] is None:
             raise ValueError(
-                "Missing the required parameter `body` when calling `update_user`"
-            )  # noqa: E501
+                "Missing the required parameter `body` "
+                "when calling `update_user`"
+            )
         # verify the required parameter 'username' is set
         if "username" not in params or params["username"] is None:
             raise ValueError(
-                "Missing the required parameter `username` when calling `update_user`"
-            )  # noqa: E501
+                "Missing the required parameter `username` "
+                "when calling `update_user`"
+            )
 
         collection_formats = {}
 

--- a/swagger_client/api_client.py
+++ b/swagger_client/api_client.py
@@ -2,7 +2,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/configuration.py
+++ b/swagger_client/configuration.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/__init__.py
+++ b/swagger_client/models/__init__.py
@@ -4,7 +4,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/api_response.py
+++ b/swagger_client/models/api_response.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/connection.py
+++ b/swagger_client/models/connection.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/link.py
+++ b/swagger_client/models/link.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/location.py
+++ b/swagger_client/models/location.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/node.py
+++ b/swagger_client/models/node.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/port.py
+++ b/swagger_client/models/port.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/topology.py
+++ b/swagger_client/models/topology.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/models/user.py
+++ b/swagger_client/models/user.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/swagger_client/rest.py
+++ b/swagger_client/rest.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_api_response.py
+++ b/test/test_api_response.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_api_response.py
+++ b/test/test_api_response.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.api_response import ApiResponse  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.api_response import ApiResponse  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestApiResponse(unittest.TestCase):

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.connection import Connection  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.connection import Connection  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestConnection(unittest.TestCase):

--- a/test/test_connection_api.py
+++ b/test/test_connection_api.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
+# import swagger_client
 from swagger_client.api.connection_api import ConnectionApi  # noqa: E501
-from swagger_client.rest import ApiException
+# from swagger_client.rest import ApiException
 
 
 class TestConnectionApi(unittest.TestCase):

--- a/test/test_connection_api.py
+++ b/test/test_connection_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_link.py
+++ b/test/test_link.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_link.py
+++ b/test/test_link.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.link import Link  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.link import Link  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestLink(unittest.TestCase):

--- a/test/test_link_api.py
+++ b/test/test_link_api.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
+# import swagger_client
 from swagger_client.api.link_api import LinkApi  # noqa: E501
-from swagger_client.rest import ApiException
+# from swagger_client.rest import ApiException
 
 
 class TestLinkApi(unittest.TestCase):

--- a/test/test_link_api.py
+++ b/test/test_link_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.location import Location  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.location import Location  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestLocation(unittest.TestCase):

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.node import Node  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.node import Node  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestNode(unittest.TestCase):

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_node_api.py
+++ b/test/test_node_api.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
+# import swagger_client
 from swagger_client.api.node_api import NodeApi  # noqa: E501
-from swagger_client.rest import ApiException
+# from swagger_client.rest import ApiException
 
 
 class TestNodeApi(unittest.TestCase):

--- a/test/test_node_api.py
+++ b/test/test_node_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.port import Port  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.port import Port  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestPort(unittest.TestCase):

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.topology import Topology  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.topology import Topology  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestTopology(unittest.TestCase):

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_topology_api.py
+++ b/test/test_topology_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_topology_api.py
+++ b/test/test_topology_api.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
+# import swagger_client
 from swagger_client.api.topology_api import TopologyApi  # noqa: E501
-from swagger_client.rest import ApiException
+# from swagger_client.rest import ApiException
 
 
 class TestTopologyApi(unittest.TestCase):

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
-from swagger_client.models.user import User  # noqa: E501
-from swagger_client.rest import ApiException
+# import swagger_client
+# from swagger_client.models.user import User  # noqa: E501
+# from swagger_client.rest import ApiException
 
 
 class TestUser(unittest.TestCase):

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_user_api.py
+++ b/test/test_user_api.py
@@ -3,7 +3,9 @@
 """
     SDX-Controller
 
-    You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).   # noqa: E501
+    You can find out more about Swagger at
+    [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).
 
     OpenAPI spec version: 1.0.0
     Contact: yxin@renci.org

--- a/test/test_user_api.py
+++ b/test/test_user_api.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import unittest
 
-import swagger_client
+# import swagger_client
 from swagger_client.api.user_api import UserApi  # noqa: E501
-from swagger_client.rest import ApiException
+# from swagger_client.rest import ApiException
 
 
 class TestUserApi(unittest.TestCase):


### PR DESCRIPTION
Just two sets of changes: 

- Commenting out some unused imports (we'll need them later when we have some actual tests)
- Breaking some overly long lines.